### PR TITLE
feat(lens): Add continuous zoom support

### DIFF
--- a/src/commandSender/baseGenerator.ts
+++ b/src/commandSender/baseGenerator.ts
@@ -86,7 +86,7 @@ export abstract class AtemCameraControlCommandGenerator<TRes> {
 			AtemCameraControlCategory.Lens,
 			AtemCameraControlLensParameter.SetContinuousZoomSpeed,
 			constructNumberProps(Commands.CameraControlDataType.FLOAT, [speed])
-		);
+		)
 
 		return this.addCommand(command)
 	}

--- a/src/commandSender/baseGenerator.ts
+++ b/src/commandSender/baseGenerator.ts
@@ -80,6 +80,17 @@ export abstract class AtemCameraControlCommandGenerator<TRes> {
 		return this.addCommand(command)
 	}
 
+	lensSetContinuousZoomSpeed(cameraId: number, speed: number): TRes {
+		const command = new Commands.CameraControlCommand(
+			cameraId,
+			AtemCameraControlCategory.Lens,
+			AtemCameraControlLensParameter.SetContinuousZoomSpeed,
+			constructNumberProps(Commands.CameraControlDataType.FLOAT, [speed])
+		);
+
+		return this.addCommand(command)
+	}
+
 	// Video
 
 	videoManualWhiteBalance(cameraId: number, colorTemperature: number, tint: number): TRes {

--- a/src/emptyState.ts
+++ b/src/emptyState.ts
@@ -11,7 +11,7 @@ export function createEmptyState(cameraId: number): AtemCameraControlState {
 			// autoIris: boolean
 			opticalImageStabilisation: false,
 			// zoomPosition: 0,
-			// zoomSpeed: 0,
+			zoomSpeed: 0,
 		},
 
 		video: {

--- a/src/state.ts
+++ b/src/state.ts
@@ -51,7 +51,7 @@ export interface AtemCameraControlState {
 		//  *  0.0 = stop
 		//  * +1.0 = zoom tele fast
 		//  */
-		// zoomSpeed: number
+		zoomSpeed: number
 	}
 
 	video: {

--- a/src/stateBuilder/lens.ts
+++ b/src/stateBuilder/lens.ts
@@ -41,12 +41,18 @@ export function applyLensCommand(
 			changes.addChange(command.source, 'lens.opticalImageStabilisation')
 			return
 		}
+		case AtemCameraControlLensParameter.SetContinuousZoomSpeed: {
+			if (!changes.checkMessageParameters(command, Commands.CameraControlDataType.FLOAT, 1)) return
+
+			state.lens.zoomSpeed = command.properties.numberData[0]
+			changes.addChange(command.source, 'lens.zoomSpeed')
+			return
+		}
 
 		case AtemCameraControlLensParameter.ApertureNormalised:
 		case AtemCameraControlLensParameter.ApertureOrdinal:
 		case AtemCameraControlLensParameter.SetAbsoluteZoomMM:
 		case AtemCameraControlLensParameter.SetAbsoluteZoomNormalised:
-		case AtemCameraControlLensParameter.SetContinuousZoomSpeed:
 			// Not implemented
 			changes.addUnhandledMessage(command)
 			return


### PR DESCRIPTION
This adds continuous zoom support for the ATEM connections.

I was able to test that with a Black Magic Studio Camera (With a zoom capable lens) connected to an Atem Mini Extreme ISO.