### PR TITLE
feat: add displayExposureAndFocusTools and outputOverlayEnables methods

### DIFF
--- a/src/commandSender/baseGenerator.ts
+++ b/src/commandSender/baseGenerator.ts
@@ -186,12 +186,7 @@ export abstract class AtemCameraControlCommandGenerator<TRes> {
 		return this.addCommand(command)
 	}
 
-	displayExposureAndFocusTools(
-		cameraId: number,
-		zebra: boolean,
-		focusAssist: boolean,
-		falseColor: boolean
-	): TRes {
+	displayExposureAndFocusTools(cameraId: number, zebra: boolean, focusAssist: boolean, falseColor: boolean): TRes {
 		const value = (zebra ? 1 : 0) + (focusAssist ? 2 : 0) + (falseColor ? 4 : 0)
 		const command = new Commands.CameraControlCommand(
 			cameraId,

--- a/src/commandSender/baseGenerator.ts
+++ b/src/commandSender/baseGenerator.ts
@@ -205,11 +205,11 @@ export abstract class AtemCameraControlCommandGenerator<TRes> {
 
 	// Output
 
-	outputOverlayEnables(cameraId: number, enable: boolean): TRes {
+	outputOverlayEnable(cameraId: number, enable: boolean): TRes {
 		const command = new Commands.CameraControlCommand(
 			cameraId,
 			AtemCameraControlCategory.Output,
-			AtemCameraControlOutputParameter.OverlayEnables,
+			AtemCameraControlOutputParameter.OverlayEnable,
 			constructNumberProps(Commands.CameraControlDataType.SINT16, [enable ? 1 : 0])
 		)
 

--- a/src/commandSender/baseGenerator.ts
+++ b/src/commandSender/baseGenerator.ts
@@ -5,6 +5,7 @@ import {
 	AtemCameraControlDisplayParameter,
 	AtemCameraControlLensParameter,
 	AtemCameraControlMediaParameter,
+	AtemCameraControlOutputParameter,
 	AtemCameraControlVideoParameter,
 } from '../ids'
 import { constructNumberProps, constructBooleanProps } from './props'
@@ -180,6 +181,36 @@ export abstract class AtemCameraControlCommandGenerator<TRes> {
 			AtemCameraControlCategory.Display,
 			AtemCameraControlDisplayParameter.ColorBarEnable,
 			constructNumberProps(Commands.CameraControlDataType.SINT8, [enable ? 30 : 0])
+		)
+
+		return this.addCommand(command)
+	}
+
+	displayExposureAndFocusTools(
+		cameraId: number,
+		zebra: boolean,
+		focusAssist: boolean,
+		falseColor: boolean
+	): TRes {
+		const value = (zebra ? 1 : 0) + (focusAssist ? 2 : 0) + (falseColor ? 4 : 0)
+		const command = new Commands.CameraControlCommand(
+			cameraId,
+			AtemCameraControlCategory.Display,
+			AtemCameraControlDisplayParameter.ExposureAndFocusTools,
+			constructNumberProps(Commands.CameraControlDataType.SINT16, [value])
+		)
+
+		return this.addCommand(command)
+	}
+
+	// Output
+
+	outputOverlayEnables(cameraId: number, enable: boolean): TRes {
+		const command = new Commands.CameraControlCommand(
+			cameraId,
+			AtemCameraControlCategory.Output,
+			AtemCameraControlOutputParameter.OverlayEnables,
+			constructNumberProps(Commands.CameraControlDataType.SINT16, [enable ? 1 : 0])
 		)
 
 		return this.addCommand(command)

--- a/src/emptyState.ts
+++ b/src/emptyState.ts
@@ -33,7 +33,16 @@ export function createEmptyState(cameraId: number): AtemCameraControlState {
 		},
 
 		display: {
+			exposureAndFocusTools: {
+				zebra: false,
+				focusAssist: false,
+				falseColor: false,
+			},
 			colorBarEnable: false,
+		},
+
+		output: {
+			overlayEnables: false,
 		},
 
 		colorCorrection: {

--- a/src/emptyState.ts
+++ b/src/emptyState.ts
@@ -42,7 +42,7 @@ export function createEmptyState(cameraId: number): AtemCameraControlState {
 		},
 
 		output: {
-			overlayEnables: false,
+			overlayEnable: false,
 		},
 
 		colorCorrection: {

--- a/src/ids.ts
+++ b/src/ids.ts
@@ -56,7 +56,7 @@ export enum AtemCameraControlAudioParameter {
 }
 
 export enum AtemCameraControlOutputParameter {
-	OverlayEnables = 0,
+	OverlayEnable = 0,
 	FrameGuidesStyleCamera3_x = 1,
 	FrameGuidesOpacityCamera3_x = 2,
 	Overlays = 3,

--- a/src/state.ts
+++ b/src/state.ts
@@ -103,7 +103,14 @@ export interface AtemCameraControlState {
 
 	display: {
 		// brightness: number
-		// exposureAndFocusTools: unknown
+
+		/** Exposure and focus tools bitmask: bit 0 = zebra, bit 1 = focus assist, bit 2 = false color */
+		exposureAndFocusTools: {
+			zebra: boolean
+			focusAssist: boolean
+			falseColor: boolean
+		}
+
 		// zebraLevel: number
 		// peakingLevel: number
 
@@ -112,6 +119,15 @@ export interface AtemCameraControlState {
 		// focusAssist: unknown
 		// programReturnFeedEnable: boolean
 		// timecodeSource: unknown
+	}
+
+	output: {
+		/** Status overlay enable */
+		overlayEnables: boolean
+
+		// frameGuidesStyle: number
+		// frameGuidesOpacity: number
+		// overlays: unknown
 	}
 
 	colorCorrection: {

--- a/src/state.ts
+++ b/src/state.ts
@@ -123,7 +123,7 @@ export interface AtemCameraControlState {
 
 	output: {
 		/** Status overlay enable */
-		overlayEnables: boolean
+		overlayEnable: boolean
 
 		// frameGuidesStyle: number
 		// frameGuidesOpacity: number

--- a/src/stateBuilder/display.ts
+++ b/src/stateBuilder/display.ts
@@ -19,8 +19,20 @@ export function applyDisplayCommand(
 			return
 		}
 
+		case AtemCameraControlDisplayParameter.ExposureAndFocusTools: {
+			if (!changes.checkMessageParameters(command, Commands.CameraControlDataType.SINT16, 1)) return
+
+			const value = command.properties.numberData[0]
+			state.display.exposureAndFocusTools = {
+				zebra: (value & 1) !== 0,
+				focusAssist: (value & 2) !== 0,
+				falseColor: (value & 4) !== 0,
+			}
+			changes.addChange(command.source, 'display.exposureAndFocusTools')
+			return
+		}
+
 		case AtemCameraControlDisplayParameter.Brightness:
-		case AtemCameraControlDisplayParameter.ExposureAndFocusTools:
 		case AtemCameraControlDisplayParameter.ZebraLevel:
 		case AtemCameraControlDisplayParameter.PeakingLevel:
 		case AtemCameraControlDisplayParameter.FocusAssist:

--- a/src/stateBuilder/output.ts
+++ b/src/stateBuilder/output.ts
@@ -10,11 +10,11 @@ export function applyOutputCommand(
 ): void {
 	const parameter = command.parameter as AtemCameraControlOutputParameter
 	switch (parameter) {
-		case AtemCameraControlOutputParameter.OverlayEnables: {
+		case AtemCameraControlOutputParameter.OverlayEnable: {
 			if (!changes.checkMessageParameters(command, Commands.CameraControlDataType.SINT16, 1)) return
 
-			state.output.overlayEnables = command.properties.numberData[0] !== 0
-			changes.addChange(command.source, 'output.overlayEnables')
+			state.output.overlayEnable = command.properties.numberData[0] !== 0
+			changes.addChange(command.source, 'output.overlayEnable')
 			return
 		}
 

--- a/src/stateBuilder/output.ts
+++ b/src/stateBuilder/output.ts
@@ -1,0 +1,33 @@
+import { Commands } from 'atem-connection'
+import { ChangesTracker, assertNever } from './changesTracker'
+import { AtemCameraControlState } from '../state'
+import { AtemCameraControlOutputParameter } from '../ids'
+
+export function applyOutputCommand(
+	changes: ChangesTracker,
+	command: Commands.CameraControlUpdateCommand,
+	state: AtemCameraControlState
+): void {
+	const parameter = command.parameter as AtemCameraControlOutputParameter
+	switch (parameter) {
+		case AtemCameraControlOutputParameter.OverlayEnables: {
+			if (!changes.checkMessageParameters(command, Commands.CameraControlDataType.SINT16, 1)) return
+
+			state.output.overlayEnables = command.properties.numberData[0] !== 0
+			changes.addChange(command.source, 'output.overlayEnables')
+			return
+		}
+
+		case AtemCameraControlOutputParameter.FrameGuidesStyleCamera3_x:
+		case AtemCameraControlOutputParameter.FrameGuidesOpacityCamera3_x:
+		case AtemCameraControlOutputParameter.Overlays:
+			// Not implemented
+			changes.addUnhandledMessage(command)
+			return
+
+		default:
+			assertNever(parameter)
+			changes.addUnhandledMessage(command)
+			return
+	}
+}

--- a/src/stateBuilder/stateBuilder.ts
+++ b/src/stateBuilder/stateBuilder.ts
@@ -5,6 +5,7 @@ import { applyVideoCommand } from './video'
 import { applyLensCommand } from './lens'
 import { applyDisplayCommand } from './display'
 import { applyColorCorrectionCommand } from './colorCorrection'
+import { applyOutputCommand } from './output'
 import { createEmptyState } from '../emptyState'
 import { AtemCameraControlCategory } from '../ids'
 import { AtemCameraControlChanges } from '../changes'
@@ -62,8 +63,10 @@ export class AtemCameraControlStateBuilder {
 				case AtemCameraControlCategory.ColorCorrection:
 					applyColorCorrectionCommand(changes, command, state)
 					break
-				case AtemCameraControlCategory.Audio:
 				case AtemCameraControlCategory.Output:
+					applyOutputCommand(changes, command, state)
+					break
+				case AtemCameraControlCategory.Audio:
 				case AtemCameraControlCategory.Tally:
 				case AtemCameraControlCategory.Reference:
 				case AtemCameraControlCategory.Configuration:


### PR DESCRIPTION
Adds command sender methods and state tracking for two previously unimplemented camera control parameters:

**Display: ExposureAndFocusTools** (category 4, parameter 1)
- `displayExposureAndFocusTools(cameraId, zebra, focusAssist, falseColor)` — sends a SINT16 bitmask combining the three flags
- State builder parses the bitmask back into individual booleans

**Output: OverlayEnables** (category 3, parameter 0)
- `outputOverlayEnables(cameraId, enable)` — sends SINT16 0/1 for status overlay toggle
- New output state builder handles the Output category (previously marked as unhandled)

Tested with a Blackmagic Pocket Cinema Camera 4K via ATEM Mini Pro.